### PR TITLE
Added asmdefs and Unity Package Manager file.

### DIFF
--- a/Assets/Gemserk/SelectionHistory/Editor/SelectionHistory-Editor-asm.asmdef
+++ b/Assets/Gemserk/SelectionHistory/Editor/SelectionHistory-Editor-asm.asmdef
@@ -1,0 +1,10 @@
+{
+    "name": "SelectionHistory-Editor-asm",
+    "references": [
+        "SelectionHistory-asm"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": []
+}

--- a/Assets/Gemserk/SelectionHistory/Editor/SelectionHistory-Editor-asm.asmdef.meta
+++ b/Assets/Gemserk/SelectionHistory/Editor/SelectionHistory-Editor-asm.asmdef.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8685a1b89c0783d4da3f517cac3e0b69
+timeCreated: 1524996822
+licenseType: Free
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Gemserk/SelectionHistory/Scripts/SelectionHistory-asm.asmdef
+++ b/Assets/Gemserk/SelectionHistory/Scripts/SelectionHistory-asm.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "SelectionHistory-asm"
+}

--- a/Assets/Gemserk/SelectionHistory/Scripts/SelectionHistory-asm.asmdef.meta
+++ b/Assets/Gemserk/SelectionHistory/Scripts/SelectionHistory-asm.asmdef.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5456f3d86baf8f549893ef314817131a
+timeCreated: 1524996845
+licenseType: Free
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Gemserk/package.json
+++ b/Assets/Gemserk/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "com.gemserk.selectionhistory",
+  "displayName": "Selection History by Gemserk",
+  "version": "1.0.0",
+  "unity": "2018.1",
+  "description": "Selection history from http://blog.gemserk.com/2017/02/13/a-simple-selection-history-window-for-unity/ and https://github.com/acoppes/unity-history-window"
+}

--- a/Assets/Gemserk/package.json.meta
+++ b/Assets/Gemserk/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 12c40a703d3176f43b051a1833f01864
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Hi,
Two changes:

1. Added Unity Assembly Definition Files so Unity versions that support don't recompile these files when others change.
2. Added a rudimentary Unity Package Manager file so relevant parts can be added to a project directly from disk via the package manager and skip the receiving project's version control, etc.  Follows instructions from https://twitter.com/lottemakesstuff/status/1089719042234089473

AFAICT adding the package directly from git isn't yet possibly since Unity as yet only pulls the root of a project (which this one has lots of other stuff in).  It's still nice to be able to Git pull to somewhere local then go into Unity's package manager, point it at the package.json file and have it all appear neatly :)

HTH