### PR TITLE
Fix npm dependency format error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Or add it manually to the `manifest.json`, like this:
 
 ```
   "dependencies": {
-    "com.gemserk.selectionhistory": "git@github.com:acoppes/unity-history-window.git#upm-package-1.0.2",
+    "com.gemserk.selectionhistory": "git+ssh://git@github.com/acoppes/unity-history-window.git#upm-package-1.0.2",
     ...
   }
 ```


### PR DESCRIPTION
Current format in readme throws:

> An error occurred while resolving packages:
  Project has invalid dependencies:
    com.gemserk.selectionhistory: Version 'git@github.com:acoppes/unity-history-window.git#upm-package-1.0.2' is invalid. Expected one of: a 'SemVer' compatible value; a value starting with 'file:'; a Git URL starting with 'git:' or 'git+', or ending with '.git'.