### PR TITLE
feat: Add mouse side button (Back/Forward) navigation with Ctrl-based Asset/Scene filtering

### DIFF
--- a/Assets/Gemserk.SelectionHistory/Editor/EditorMouseNavigator.cs
+++ b/Assets/Gemserk.SelectionHistory/Editor/EditorMouseNavigator.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Runtime.InteropServices;
+using UnityEditor;
+using UnityEngine;
+
+namespace Gemserk
+{
+    /// <summary>
+    /// Polls mouse side buttons (Back/Forward) editor-wide using native APIs,
+    /// and navigates selection history with context-aware filtering based on Ctrl key state.
+    /// 
+    /// - Mouse Back/Forward (without Ctrl): Navigate Asset entries only (Project View context)
+    /// - Ctrl + Mouse Back/Forward: Navigate Scene Object entries only (Hierarchy View context)
+    /// 
+    /// Reference: GitHub Issue #27, polling approach by lgarczyn
+    /// </summary>
+    [InitializeOnLoad]
+    public static class EditorMouseNavigator
+    {
+#if UNITY_EDITOR_WIN
+        // Windows P/Invoke — async polling for mouse/keyboard state
+        [DllImport("user32.dll")]
+        private static extern short GetAsyncKeyState(int vKey);
+
+        // Virtual key codes
+        private const int VK_XBUTTON1 = 0x05;  // Mouse Back button
+        private const int VK_XBUTTON2 = 0x06;  // Mouse Forward button
+        private const int VK_CONTROL  = 0x11;  // Ctrl key
+
+#elif UNITY_EDITOR_OSX
+        // macOS: Poll mouse button state via NSEvent.pressedMouseButtons
+        [DllImport("/System/Library/Frameworks/AppKit.framework/AppKit")]
+        private static extern IntPtr objc_getClass(string className);
+
+        [DllImport("/System/Library/Frameworks/AppKit.framework/AppKit")]
+        private static extern IntPtr sel_registerName(string name);
+
+        [DllImport("/System/Library/Frameworks/AppKit.framework/AppKit")]
+        private static extern uint objc_msgSend_uint(IntPtr receiver, IntPtr selector);
+
+        // macOS: Poll Ctrl key state via NSEvent.modifierFlags
+        [DllImport("/System/Library/Frameworks/AppKit.framework/AppKit")]
+        private static extern ulong objc_msgSend_ulong(IntPtr receiver, IntPtr selector);
+
+        // NSEventModifierFlagControl = 1 << 18
+        private const ulong NSEventModifierFlagControl = 1UL << 18;
+#endif
+
+        // Previous frame button state — used for rising edge detection.
+        // Initialized to true to prevent false triggers if buttons are already held at editor startup.
+        private static bool s_BackPressed = true;
+        private static bool s_ForwardPressed = true;
+
+        static EditorMouseNavigator()
+        {
+            EditorApplication.update += PollMouseButtons;
+        }
+
+        private static void PollMouseButtons()
+        {
+            bool backState = false;
+            bool forwardState = false;
+            bool ctrlState = false;
+
+            try
+            {
+#if UNITY_EDITOR_WIN
+                // Windows: GetAsyncKeyState — bit 0x8000 is set if key is currently pressed
+                backState    = (GetAsyncKeyState(VK_XBUTTON1) & 0x8000) != 0;
+                forwardState = (GetAsyncKeyState(VK_XBUTTON2) & 0x8000) != 0;
+                ctrlState    = (GetAsyncKeyState(VK_CONTROL)  & 0x8000) != 0;
+                
+#elif UNITY_EDITOR_OSX
+                // macOS: NSEvent.pressedMouseButtons bitmask
+                IntPtr nsEventClass = objc_getClass("NSEvent");
+                IntPtr pressedSel = sel_registerName("pressedMouseButtons");
+                uint pressedButtons = objc_msgSend_uint(nsEventClass, pressedSel);
+
+                // Bit 3 = Mouse Button 4 (Back), Bit 4 = Mouse Button 5 (Forward)
+                backState    = (pressedButtons & (1u << 3)) != 0;
+                forwardState = (pressedButtons & (1u << 4)) != 0;
+
+                // macOS: Check Ctrl state via NSEvent.modifierFlags
+                IntPtr modSel = sel_registerName("modifierFlags");
+                ulong modFlags = objc_msgSend_ulong(nsEventClass, modSel);
+                ctrlState = (modFlags & NSEventModifierFlagControl) != 0;
+#endif
+            }
+            catch
+            {
+                // Silently ignore native call failures — will retry next frame
+                return;
+            }
+
+            // Rising edge detection: was released last frame, now pressed = click event
+            if (backState && !s_BackPressed)
+            {
+                HandleNavigation(isForward: false, isCtrlHeld: ctrlState);
+            }
+
+            if (forwardState && !s_ForwardPressed)
+            {
+                HandleNavigation(isForward: true, isCtrlHeld: ctrlState);
+            }
+
+            // Save state for next frame comparison
+            s_BackPressed = backState;
+            s_ForwardPressed = forwardState;
+        }
+
+        /// <summary>
+        /// Handles mouse button click — determines filtering context based on Ctrl key state.
+        /// Wrapped in delayCall to safely modify Selection from main editor loop.
+        /// </summary>
+        private static void HandleNavigation(bool isForward, bool isCtrlHeld)
+        {
+            EditorApplication.delayCall += () =>
+            {
+                var selectionHistory = SelectionHistoryAsset.instance.selectionHistory;
+                if (selectionHistory == null || selectionHistory.History.Count == 0)
+                    return;
+
+                // Without Ctrl: Asset (Project View) context
+                // With Ctrl:    Scene Object (Hierarchy View) context
+                Func<SelectionHistory.Entry, bool> predicate;
+                if (isCtrlHeld)
+                    predicate = entry => entry.isSceneInstance; // Hierarchy: Scene objects only
+                else
+                    predicate = entry => entry.isAsset;        // Project: Asset objects only
+
+                bool found = isForward
+                    ? selectionHistory.NextFiltered(predicate)
+                    : selectionHistory.PreviousFiltered(predicate);
+
+                if (found)
+                {
+                    Selection.activeObject = selectionHistory.GetSelection();
+                }
+            };
+        }
+    }
+}

--- a/Assets/Gemserk.SelectionHistory/Editor/EditorMouseNavigator.cs.meta
+++ b/Assets/Gemserk.SelectionHistory/Editor/EditorMouseNavigator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f9a2e569bdb1e747b5aef50d525ec74
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Gemserk.SelectionHistory/SelectionHistory.cs
+++ b/Assets/Gemserk.SelectionHistory/SelectionHistory.cs
@@ -17,7 +17,7 @@ namespace Gemserk
             return false;
         }
     }
-    
+
     [Serializable]
     public class SelectionHistory
     {
@@ -62,7 +62,7 @@ namespace Gemserk
 
             // private bool unnamed;
             // private string unnamedName;
-            
+
             public string globalObjectId;
 
             private string unreferencedObjectName;
@@ -81,12 +81,12 @@ namespace Gemserk
                 {
                     if (Reference)
                     {
-                        return string.IsNullOrEmpty(Reference.name) 
-                            ? Reference.GetType().Name 
+                        return string.IsNullOrEmpty(Reference.name)
+                            ? Reference.GetType().Name
                             : Reference.name;
                     }
                     return unreferencedObjectName;
-                }   
+                }
             }
 
             public Entry(Object reference)
@@ -101,17 +101,25 @@ namespace Gemserk
 
                 if (reference is GameObject go)
                 {
-                    if (!string.IsNullOrEmpty(go.scene.name))
+                    // Use go.scene.isLoaded instead of go.scene.name to match
+                    // SelectionHistoryUtils.IsSceneObject() behavior.
+                    // Untitled scenes have empty scene.name, which previously caused
+                    // scene objects to be misclassified as assets.
+                    if (go.scene.isLoaded)
                     {
                         this.reference = null;
                         hierarchyObjectReference = reference;
-                        
-                        sceneName = go.scene.name;
+
+                        // scene.name can be empty for untitled scenes,
+                        // use a fallback name in that case
+                        sceneName = string.IsNullOrEmpty(go.scene.name)
+                            ? "(Untitled)"
+                            : go.scene.name;
                         scenePath = go.scene.path;
-                        
-                        #if UNITY_EDITOR
+
+#if UNITY_EDITOR
                         globalObjectId = UnityEditor.GlobalObjectId.GetGlobalObjectIdSlow(reference).ToString();
-                        #endif
+#endif
                     }
                 }
             }
@@ -122,7 +130,7 @@ namespace Gemserk
                 {
                     return false;
                 }
-                
+
                 if (ReferenceEquals(this, other))
                 {
                     return true;
@@ -133,7 +141,7 @@ namespace Gemserk
                     return string.Equals(scenePath, other.scenePath) &&
                            string.Equals(globalObjectId, other.globalObjectId);
                 }
-                
+
                 return Equals(Reference, other.Reference);
             }
 
@@ -142,7 +150,7 @@ namespace Gemserk
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
                 if (obj.GetType() != this.GetType()) return false;
-                return Equals((Entry) obj);
+                return Equals((Entry)obj);
             }
 
             public override int GetHashCode()
@@ -159,10 +167,10 @@ namespace Gemserk
                 return State.ReferenceDestroyed;
             }
         }
-        
+
         public int historySize = 200;
 
-        [SerializeField] 
+        [SerializeField]
         private List<Entry> _history = new List<Entry>(100);
 
         private int currentSelectionIndex;
@@ -178,9 +186,9 @@ namespace Gemserk
                 return null;
             }
         }
-        
+
         public List<Entry> History => _history;
-        
+
         public event Action<SelectionHistory> OnNewEntryAdded;
 
         public bool IsSelected(int index)
@@ -226,7 +234,7 @@ namespace Gemserk
 
             var isLastSelected = lastSelectedObject != null && lastSelectedObject.Reference == selection;
             var isCurrentSelection = currentSelection != null && currentSelection.Reference == selection;
-            
+
             if (!isLastSelected && !isCurrentSelection)
             {
                 _history.Add(new Entry(selection));
@@ -238,7 +246,7 @@ namespace Gemserk
                 _history.RemoveRange(0, _history.Count - historySize);
                 //			_history.RemoveAt(0);
             }
-            
+
             if (!isLastSelected && !isCurrentSelection)
             {
                 OnNewEntryAdded?.Invoke(this);
@@ -265,6 +273,48 @@ namespace Gemserk
                 currentSelectionIndex = _history.Count - 1;
         }
 
+        /// <summary>
+        /// Searches backward (toward older entries) from the current index for the first entry
+        /// matching the predicate. If no match is found, the index remains unchanged.
+        /// </summary>
+        public bool PreviousFiltered(Func<Entry, bool> predicate)
+        {
+            if (_history.Count == 0 || predicate == null)
+                return false;
+
+            for (int i = currentSelectionIndex - 1; i >= 0; i--)
+            {
+                var entry = _history[i];
+                if (entry.GetReferenceState() == Entry.State.Referenced && predicate(entry))
+                {
+                    currentSelectionIndex = i;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Searches forward (toward newer entries) from the current index for the first entry
+        /// matching the predicate. If no match is found, the index remains unchanged.
+        /// </summary>
+        public bool NextFiltered(Func<Entry, bool> predicate)
+        {
+            if (_history.Count == 0 || predicate == null)
+                return false;
+
+            for (int i = currentSelectionIndex + 1; i < _history.Count; i++)
+            {
+                var entry = _history[i];
+                if (entry.GetReferenceState() == Entry.State.Referenced && predicate(entry))
+                {
+                    currentSelectionIndex = i;
+                    return true;
+                }
+            }
+            return false;
+        }
+
         public void SetSelection(Object obj)
         {
             currentSelectionIndex = _history.FindIndex(e => obj.Equals(e.Reference));
@@ -275,7 +325,7 @@ namespace Gemserk
             var deletedCount = _history.Count(e => e.GetReferenceState() == state);
 
             var currentSelectionDestroyed = currentSelection == null || currentSelection.GetReferenceState() == state;
-            
+
             _history.RemoveAll(e => e.GetReferenceState() == state);
 
             currentSelectionIndex -= deletedCount;
@@ -307,7 +357,7 @@ namespace Gemserk
 
             if (currentSelectionIndex >= _history.Count)
                 currentSelectionIndex = _history.Count - 1;
-        
+
         }
     }
 }


### PR DESCRIPTION
## Summary

Add mouse side button (XBUTTON1/XBUTTON2) support for navigating selection history
with context-aware filtering based on Ctrl key state.

### New Feature: Mouse Side Button Navigation

- **Mouse Back / Forward** (without Ctrl): Navigate only through **Asset** entries
  (Project View context)
- **Ctrl + Mouse Back / Forward**: Navigate only through **Scene Object** entries
  (Hierarchy View context)

Uses native `GetAsyncKeyState` polling (Windows) and `NSEvent.pressedMouseButtons`
(macOS) via `EditorApplication.update` for cross-platform editor-wide input detection.

Reference: #27

### Bug Fix: Scene objects in untitled scenes classified as Assets

Fixed `SelectionHistory.Entry` constructor using `go.scene.name` (empty string for
untitled scenes) instead of `go.scene.isLoaded` to determine scene objects. This caused
all hierarchy objects in unsaved scenes to be incorrectly classified as Assets.

The detection now uses `go.scene.isLoaded`, consistent with `SelectionHistoryUtils.IsSceneObject()`.

### Changed Files

| File | Change |
|---|---|
| `EditorMouseNavigator.cs` | **[NEW]** Native polling + Ctrl-based filtered navigation |
| `SelectionHistory.cs` | **[MOD]** Added `PreviousFiltered()`/`NextFiltered()` methods; Fixed scene object detection |
